### PR TITLE
add setup-template make command to update repo name occurrences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,17 @@ gqlgen:
 	go run github.com/99designs/gqlgen generate --verbose
 	go mod tidy
 	go run ./gen_schema.go
-	@echo "******************* generating gqlgen client ********************)"
+	@echo "******************* generating gqlgen client ********************"
 	go run github.com/Yamashou/gqlgenc generate --configdir schema
 
 generate: ent graph gqlgen
 
 run-dev:
 	go run main.go serve  --debug --pretty --dev
+
+setup-template:
+	@echo "******************** removing template name occurances ********************"
+	bash scripts/clean.sh
 
 clean:
 	$(info ******************** removing generated files from repo ********************)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ brew install gomplate
 ## Usage
 
 ### Cleanup 
-1. After cloning the repo, you will need to update all occurrences of `go-template` with your repo name
+1. After cloning the repo, you will need to update all occurrences of `go-template` with your repo name. For convenience, a `make` command is included:
+```bash
+make setup-template
+```
 
 ### Schema Generation with Ent
 1. As the tooling suggests, this is schema driven api development so first up, is defining your schema

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -4,11 +4,8 @@
 appName=go-template
 appVariation=${appName/"-"/""}
 
-#What we want to update to 
+#what we want to update to 
 newAppName=${PWD##*/}  
-
-#for testing
-newAppName="blah"
 newAppVariation=${newAppName/"-"/""}
 
 echo +++ Update repo occurances with $newAppName

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Find all occurances of `go-template` and its variations and replace with current directory name
+appName=go-template
+appVariation=${appName/"-"/""}
+
+#What we want to update to 
+newAppName=${PWD##*/}  
+
+#for testing
+newAppName="blah"
+newAppVariation=${newAppName/"-"/""}
+
+echo +++ Update repo occurances with $newAppName
+git grep -lz $appName | xargs -0 sed -i '' -e "s/${appName}/${newAppName}/g"
+
+echo +++ Update variations with $appVariation
+git grep -lz $appVariation | xargs -0 sed -i '' -e "s/${appVariation}/${newAppVariation}/g"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -ueo pipefail
 # Find all occurances of `go-template` and its variations and replace with current directory name
 appName=go-template
 appVariation=${appName/"-"/""}


### PR DESCRIPTION
With `go`, we have a lot of internal references to repo packages, as wells config setups. Instead of having the user that clones the repo be required to find these and make sure they know the variances, I've added a basic cleanup script that will do find  and replace these. 