### PR TITLE
entx version change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/datumforge/echo-prometheus/v5 v5.0.0-20240521143548-d561656e6328
 	github.com/datumforge/echox v0.1.1
 	github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c
-	github.com/datumforge/entx v0.2.2
+	github.com/datumforge/entx v0.3.0
 	github.com/datumforge/fgax v0.3.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,8 @@ github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c h1:4ycAoM6MJ8PB
 github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c/go.mod h1:Tp6J3q+sRxvsMLHCxARnBouLUiwWnquxmDgRjqJaLHw=
 github.com/datumforge/enthistory v0.0.9 h1:jA1zvzoqTXfBtPhuWrZhqoeCUB6gGMpBXSA1MO8923U=
 github.com/datumforge/enthistory v0.0.9/go.mod h1:QVPj2xf/7bSWf8iXsyHKR5j8r+CKYGSbHYeS6lwg28U=
-github.com/datumforge/entx v0.2.2 h1:KV3sDvzHRx3Gj1H6zKIptD04imDu6wAZtzAvGNFjiE0=
-github.com/datumforge/entx v0.2.2/go.mod h1:C+yfsVDEuBjNTXHTr8rFBxvi+zwHkkxTU5Rn6xeqnBM=
+github.com/datumforge/entx v0.3.0 h1:XfM/hufZ016xvFI9qNBs+Kurex0GO6njnN+zk/PYRxY=
+github.com/datumforge/entx v0.3.0/go.mod h1:IwllghPmZhlmLy7fCHF/Noeqa3vcrV3oAXxbQOYuT/4=
 github.com/datumforge/fgax v0.3.1 h1:M454Yb88KLcuKBkWWro5X8tzy7sQ/BC1mcgg5hnfxAE=
 github.com/datumforge/fgax v0.3.1/go.mod h1:Ca/0Yjmrf+IQwsE0Fb1Ny9s0SeRzD3g7qvXsrHHiUmA=
 github.com/datumforge/geodetic v0.0.3 h1:nyUJhUh3+jeezlUoPvUEUQFQI8n5vlb1FuKOhTI3tow=


### PR DESCRIPTION
Preemptively changed `github.com/datumforge/entx v0.2.2` to `github.com/datumforge/entx v0.3.0` to represent the changes made in the entx repo.